### PR TITLE
Make Material use String instead of ResourceLocation 

### DIFF
--- a/src/main/java/io/github/ageuxo/gloriousgunpowder/data/Material.java
+++ b/src/main/java/io/github/ageuxo/gloriousgunpowder/data/Material.java
@@ -5,13 +5,12 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.ageuxo.gloriousgunpowder.GloriousGunpowderMod;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 
-public record Material(ResourceLocation id, float damage, float equipSpeed, float reloadSpeed) {
+public record Material(String name, float damage, float equipSpeed, float reloadSpeed) {
     public static final ResourceKey<Registry<Material>> KEY = ResourceKey.createRegistryKey(GloriousGunpowderMod.rl("material"));
     public static final Codec<Material> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    ResourceLocation.CODEC.fieldOf("id").forGetter(Material::id),
+                    Codec.STRING.fieldOf("name").forGetter(Material::name),
                     Codec.FLOAT.fieldOf("damage").forGetter(Material::damage),
                     Codec.FLOAT.fieldOf("equipSpeed").forGetter(Material::equipSpeed),
                     Codec.FLOAT.fieldOf("reloadSpeed").forGetter(Material::reloadSpeed)


### PR DESCRIPTION
Change Material to use a String based name instead of being tied to a ResLoc